### PR TITLE
SSL check fails

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -90,7 +90,7 @@
                         <echo msg="Existing 'var/build/pimcore-distribution.zip' found - using it." />
                     </then>
                     <else>
-                        <httpget url="${pimcore.downloadUrl}" dir="var/build" filename="pimcore-distribution.zip"/>
+			<httpget url="${pimcore.downloadUrl}" dir="var/build" filename="pimcore-distribution.zip" sslVerifyPeer="false"/>
                     </else>
                 </if>
 


### PR DESCRIPTION
This removes the SSL cert check from the installation. It is REALLY a bad idea, to do this, but I have no clue, why this check fails. It seems the CA of the image is too old - no clue how to update.
